### PR TITLE
Role::Tiny->make_role($package)

### DIFF
--- a/lib/Role/Tiny.pm
+++ b/lib/Role/Tiny.pm
@@ -60,6 +60,11 @@ sub import {
   strict->import;
   warnings->import;
   $me->_install_subs($target);
+  $me->make_role($target);
+}
+
+sub make_role {
+  my ($me, $target) = @_;
   return if $me->is_role($target); # already exported into this package
   $INFO{$target}{is_role} = 1;
   # get symbol table reference
@@ -666,6 +671,13 @@ New class is returned.
  Role::Tiny->is_role('Some::Role1')
 
 Returns true if the given package is a role.
+
+=head2 make_role
+
+  Role::Tiny->make_role('Some::Package');
+
+Promotes a given package to a role.
+No subroutines are imported into C<'Some::Package'>.
 
 =head1 CAVEATS
 

--- a/t/make-role.t
+++ b/t/make-role.t
@@ -1,0 +1,23 @@
+
+use strict;
+use warnings;
+use Test::More;
+
+use Role::Tiny ();
+
+Role::Tiny->make_role('Foo');
+{
+  no warnings 'once';
+  *Foo::foo = sub {42};
+}
+
+ok( Role::Tiny->is_role('Foo'), 'Foo is_role');
+
+for my $m (qw(requires with before around after)) {
+  ok( !Foo->can($m), "Foo cannot '$m'" );
+}
+
+Role::Tiny->apply_roles_to_package('FooFoo', 'Foo');
+can_ok 'FooFoo', 'foo';
+
+done_testing;


### PR DESCRIPTION
This method isolates the creation of a role
from the installation of subroutines (requires, etc.) 
as done by `Role::Tiny::import`.

It may be used for programmatic creation of roles in runtime
(vs compile-time) and to make easier to extend and modify
the basic `Role::Tiny` features.

---

The real gain may be tiny, but for achieving
```
Role::Tiny->make_role($package);
```
with the current code, it is necessary to do a string eval
```
eval "package $package; use Role::Tiny";
```
due to the use of `caller` in `Role::Tiny::import`.
Furthermore this has the additional effect of polluting the target 
package with `requires`, `with`, `around`, `after`, and `before` which
may not be desired. 